### PR TITLE
WIP: Add readonly, min-height attributes and faust-editor-basic "passive" variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 > and `min-height` for setting a minimum height as CSS prop to the editor element  
 > Additional variant \<faust-editor-basic\> without buttons for dynamic editor  
 > Aims to bring a lightweight variant, see [the demo](https://synthe.tiseur.fr/faust-web-component/#readonlyandbasic) or an usecase in [my other project](https://github.com/Simon-L/pasfa)
+> Build the basic variant only using: `FAUST_WEB_BASIC=true npm run build`. Much smaller size but obviously doesn't allow compiling DSP.
 
 This package provides two [web components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) for embedding interactive [Faust](https://faust.grame.fr) snippets in web pages.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > Additional variant \<faust-editor-basic\> without buttons for dynamic editor  
 > Aims to bring a lightweight variant, see [the demo](https://synthe.tiseur.fr/faust-web-component/#readonlyandbasic)  
 > or an usecase in [my other project](https://github.com/Simon-L/pasfa)  
-> Build the basic variant only using: `FAUST_WEB_BASIC=true npm run build`. Much smaller size but obviously doesn't allow compiling DSP.  
+> `dist/faust-web-component-basic.js` contains only the basic variant, it's much smaller in size but obviously doesn't allow compiling DSP.  
 
 This package provides two [web components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) for embedding interactive [Faust](https://faust.grame.fr) snippets in web pages.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # faust-web-component
 
-> :warning: This is a fork!
+> :warning: This is a fork !  
+>
+> Features in fork: passive boolean attribute for read-only editor  
+> and min-height for setting a minimum height as CSS prop to the editor element  
+> Additional variant \<faust-editor-basic\> without buttons for dynamic editor  
+> Aims to bring a lightweight variant, see usecase in [my other project](https://github.com/Simon-L/pasfa)
 
 This package provides two [web components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) for embedding interactive [Faust](https://faust.grame.fr) snippets in web pages.
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 > Features in fork: `readonly` boolean attribute for read-only editor  
 > and `min-height` for setting a minimum height as CSS prop to the editor element  
 > Additional variant \<faust-editor-basic\> without buttons for dynamic editor  
-> Aims to bring a lightweight variant, see [the demo](https://synthe.tiseur.fr/faust-web-component/#readonlyandbasic) or an usecase in [my other project](https://github.com/Simon-L/pasfa)
-> Build the basic variant only using: `FAUST_WEB_BASIC=true npm run build`. Much smaller size but obviously doesn't allow compiling DSP.
+> Aims to bring a lightweight variant, see [the demo](https://synthe.tiseur.fr/faust-web-component/#readonlyandbasic)  
+> or an usecase in [my other project](https://github.com/Simon-L/pasfa)  
+> Build the basic variant only using: `FAUST_WEB_BASIC=true npm run build`. Much smaller size but obviously doesn't allow compiling DSP.  
 
 This package provides two [web components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) for embedding interactive [Faust](https://faust.grame.fr) snippets in web pages.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # faust-web-component
 
+> :warning: This is a fork!
+
 This package provides two [web components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) for embedding interactive [Faust](https://faust.grame.fr) snippets in web pages.
 
 - `<faust-editor>` displays an editor (using [CodeMirror 6](https://codemirror.net/)) with executable, editable Faust code, along with some bells & whistles (controls, block diagram, plots) in a side pane.
 This component is ideal for demonstrating some code in Faust and allowing the reader to try it out and tweak it themselves without having to leave the page. (For more extensive work, it also includes a button to open the code in the Faust IDE.)
+    * `passive` attributes disables playback and makes editor read-only
 
 - `<faust-widget>` just shows the controls and does not allow editing, so it serves simply as a way to embed interactive DSP.
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,17 @@
 
 > :warning: This is a fork !  
 >
-> Features in fork: passive boolean attribute for read-only editor  
-> and min-height for setting a minimum height as CSS prop to the editor element  
+> Features in fork: `readonly` boolean attribute for read-only editor  
+> and `min-height` for setting a minimum height as CSS prop to the editor element  
 > Additional variant \<faust-editor-basic\> without buttons for dynamic editor  
-> Aims to bring a lightweight variant, see usecase in [my other project](https://github.com/Simon-L/pasfa)
+> Aims to bring a lightweight variant, see [the demo](https://synthe.tiseur.fr/faust-web-component/#readonlyandbasic) or an usecase in [my other project](https://github.com/Simon-L/pasfa)
 
 This package provides two [web components](https://developer.mozilla.org/en-US/docs/Web/API/Web_components) for embedding interactive [Faust](https://faust.grame.fr) snippets in web pages.
 
 - `<faust-editor>` displays an editor (using [CodeMirror 6](https://codemirror.net/)) with executable, editable Faust code, along with some bells & whistles (controls, block diagram, plots) in a side pane.
 This component is ideal for demonstrating some code in Faust and allowing the reader to try it out and tweak it themselves without having to leave the page. (For more extensive work, it also includes a button to open the code in the Faust IDE.)
-    * `passive` attributes disables playback and makes editor read-only
+    * `readonly` : attribute disables playback and makes editor read-only.
+    * `min-height` : attribute to set the min-height CSS property, the value must be valid CSS value eg. "42px", "1.5em".
 
 - `<faust-widget>` just shows the controls and does not allow editing, so it serves simply as a way to embed interactive DSP.
 

--- a/index.html
+++ b/index.html
@@ -53,6 +53,19 @@ process =
     dm.zita_light; // stereo reverb
                 -->
             </faust-editor>
+            <p>Excepteur sint occaecat cupidatat non proident, sunt meserunt mollit id est laborum.</p>
+            <faust-editor passive>
+                <!--
+// This editor is "passive", it's read-only and doesn't offer playback
+import("stdfaust.lib");
+process = 
+    dm.cubicnl_demo : // distortion 
+    dm.wah4_demo <: // wah pedal
+    dm.phaser2_demo : // stereo phaser 
+    dm.compressor_demo : // stereo compressor
+    dm.zita_light; // stereo reverb
+                -->
+            </faust-editor>
             <p>Minus, ducimus consequuntur? Corrupti animi aut magni nihil, dolor eos tenetur, autem deserunt et iure culpa, suscipit minus quia velit laudantium asperiores.</p>
             <faust-widget>
 <!--

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     </head>
     <body>
         <div id="content">
+            <a href="#readonlyandbasic">Readonly and basic editor examples</a>
             <p>Lorem ipsum dolor sit amet consectetur adipisicing elit.</p>
             <faust-editor>
 import("stdfaust.lib");
@@ -53,10 +54,11 @@ process =
     dm.zita_light; // stereo reverb
                 -->
             </faust-editor>
-            <p>Excepteur sint occaecat cupidatat non proident, sunt meserunt mollit id est laborum.</p>
-            <faust-editor passive>
+            <a id="readonlyandbasic"></a>
+            <p>Read-only editor</p>
+            <faust-editor readonly>
                 <!--
-// This editor is "passive", it's read-only and doesn't offer playback
+// This editor is readonly
 import("stdfaust.lib");
 process = 
     dm.cubicnl_demo : // distortion 
@@ -66,6 +68,32 @@ process =
     dm.zita_light; // stereo reverb
                 -->
             </faust-editor>
+            <p>Basic editor without playback</p>
+            <faust-editor-basic>
+                <!--
+// This editor is "basic", it doesn't offer playback
+import("stdfaust.lib");
+process = 
+    dm.cubicnl_demo : // distortion 
+    dm.wah4_demo <: // wah pedal
+    dm.phaser2_demo : // stereo phaser 
+    dm.compressor_demo : // stereo compressor
+    dm.zita_light; // stereo reverb
+                -->
+            </faust-editor-basic>
+            <p>Read-only basic editor without playback</p>
+            <faust-editor-basic readonly>
+                <!--
+// This editor is "basic", it doesn't offer playback
+import("stdfaust.lib");
+process = 
+    dm.cubicnl_demo : // distortion 
+    dm.wah4_demo <: // wah pedal
+    dm.phaser2_demo : // stereo phaser 
+    dm.compressor_demo : // stereo compressor
+    dm.zita_light; // stereo reverb
+                -->
+            </faust-editor-basic>
             <p>Minus, ducimus consequuntur? Corrupti animi aut magni nihil, dolor eos tenetur, autem deserunt et iure culpa, suscipit minus quia velit laudantium asperiores.</p>
             <faust-widget>
 <!--

--- a/package.json
+++ b/package.json
@@ -10,12 +10,13 @@
         "tsconfig.json",
         "vite.config.js",
         "dist/faust-web-component.js",
+        "dist/faust-web-component-basic.js",
         "dist/02-XYLO1.mp3"
     ],
     "type": "module",
     "scripts": {
         "dev": "vite",
-        "build": "vite build",
+        "build": "vite build && vite build --mode basic",
         "preview": "vite preview"
     },
     "repository": {

--- a/src/common.ts
+++ b/src/common.ts
@@ -3,9 +3,9 @@ import jsURL from "@grame/faustwasm/libfaust-wasm/libfaust-wasm.js?url"
 import dataURL from "@grame/faustwasm/libfaust-wasm/libfaust-wasm.data?url"
 import wasmURL from "@grame/faustwasm/libfaust-wasm/libfaust-wasm.wasm?url"
 import { library } from "@fortawesome/fontawesome-svg-core"
-import { faPlay, faStop, faUpRightFromSquare, faSquareCaretLeft, faAnglesLeft, faAnglesRight, faSliders, faDiagramProject, faWaveSquare, faChartLine, faPowerOff } from "@fortawesome/free-solid-svg-icons"
+import { faPlay, faStop, faUpRightFromSquare, faSquareCaretLeft, faAnglesLeft, faAnglesRight, faSliders, faDiagramProject, faWaveSquare, faChartLine, faPowerOff, faCopy } from "@fortawesome/free-solid-svg-icons"
 
-for (const icon of [faPlay, faStop, faUpRightFromSquare, faSquareCaretLeft, faAnglesLeft, faAnglesRight, faSliders, faDiagramProject, faWaveSquare, faChartLine, faPowerOff]) {
+for (const icon of [faPlay, faStop, faUpRightFromSquare, faSquareCaretLeft, faAnglesLeft, faAnglesRight, faSliders, faDiagramProject, faWaveSquare, faChartLine, faPowerOff, faCopy]) {
     library.add(icon)
 }
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -32,7 +32,7 @@ const faustLanguage = StreamLanguage.define(clike({
     }
 }))
 
-export function createEditor(parent: HTMLElement, doc: string, editable: boolean = true) {
+export function createEditor(parent: HTMLElement, doc: string, readonly: boolean = false) {
     return new EditorView({
         parent,
         doc,
@@ -63,7 +63,7 @@ export function createEditor(parent: HTMLElement, doc: string, editable: boolean
                 ...lintKeymap
             ]),
             faustLanguage,
-            EditorState.readOnly.of(!editable)
+            EditorState.readOnly.of(readonly)
         ],
     })
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -32,7 +32,7 @@ const faustLanguage = StreamLanguage.define(clike({
     }
 }))
 
-export function createEditor(parent: HTMLElement, doc: string) {
+export function createEditor(parent: HTMLElement, doc: string, editable: boolean = true) {
     return new EditorView({
         parent,
         doc,
@@ -63,6 +63,7 @@ export function createEditor(parent: HTMLElement, doc: string) {
                 ...lintKeymap
             ]),
             faustLanguage,
+            EditorView.editable.of(editable)
         ],
     })
 }

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -63,7 +63,7 @@ export function createEditor(parent: HTMLElement, doc: string, editable: boolean
                 ...lintKeymap
             ]),
             faustLanguage,
-            EditorView.editable.of(editable)
+            EditorState.readOnly.of(!editable)
         ],
     })
 }

--- a/src/faust-editor-basic.ts
+++ b/src/faust-editor-basic.ts
@@ -1,0 +1,172 @@
+import { icon } from "@fortawesome/fontawesome-svg-core"
+import faustCSS from "@shren/faust-ui/dist/esm/index.css?inline"
+import { createEditor, setError, clearError } from "./editor"
+import faustSvg from "./faustText.svg"
+
+function editorTemplate(passive: boolean = false, minHeight: string = "") {
+    const hidden = passive ? "hidden" : ""
+    const editorMinHeight = minHeight != "" ? `min-height: ${minHeight};` : ""
+    const template = document.createElement("template")
+    template.innerHTML = `
+    <div id="root">
+        <div id="controls">
+            <a title="Open in Faust IDE" id="ide" href="https://faustide.grame.fr/" class="button" target="_blank">${icon({ prefix: "fas", iconName: "up-right-from-square" }).html[0]}</a>
+            <button title="Copy" class="button" id="copy">${icon({ prefix: "fas", iconName: "copy" }).html[0]}</button>
+            <a title="Faust website" id="faust" href="https://faust.grame.fr/" target="_blank"><img src="${faustSvg}" height="15px" /></a>
+        </div>
+        <div id="content">
+            <div id="editor"></div>
+        </div>
+    </div>
+    <style>
+        #root {
+            overflow:hidden;
+            border: 1px solid black;
+            border-radius: 5px;
+            box-sizing: border-box;
+        }
+
+        *, *:before, *:after {
+            box-sizing: inherit; 
+        }
+        
+        #controls {
+            background-color: #384d64;
+            border-bottom: 1px solid black;
+            display: flex;
+        }
+
+        #faust {
+            margin-left: auto;
+            margin-right: 10px;
+            display: flex;
+            align-items: center;
+        }
+
+        #content {
+            display: flex;
+        }
+
+        #editor {
+            flex-grow: 1;
+            overflow-y: auto;
+        }
+
+        #editor .cm-editor {
+            height: 100%;
+            ${minHeight != "" ? `min-height: ${minHeight};` : ""}
+        }
+
+        .cm-diagnostic {
+            font-family: monospace;
+        }
+
+        .cm-diagnostic-error {
+            background-color: #fdf2f5 !important;
+            color: #a4000f !important;
+            border-color: #a4000f !important;
+        }
+
+        a.button {
+            appearance: button;
+        }
+
+        .button {
+            background-color: #384d64;
+            border: 0;
+            padding: 5px;
+            width: 25px;
+            height: 25px;
+            color: #fff;
+        }
+
+        .button:hover {
+            background-color: #4b71a1;
+        }
+
+        .button:active {
+            background-color: #373736;
+        }
+
+        .button:disabled {
+            opacity: 0.65;
+            cursor: not-allowed;
+            pointer-events: none;
+        }
+
+        #controls > .button > svg {
+            width: 15px;
+            height: 15px;
+            vertical-align: top;
+        }
+
+        ${faustCSS}
+    </style>
+    `
+    return template
+}
+
+export default class FaustEditorBasic extends HTMLElement {
+    constructor() {
+        super()
+    }
+    
+    passive = false
+    minHeight = null
+    editor = null
+    
+    getCodeString() {
+        return this.editor.state.doc.toString()
+    }
+    
+    setCode(code) {
+        this.editor.dispatch({
+          changes: {from: 0, to: this.editor.state.doc.length, insert: code}
+        })
+    }
+
+    connectedCallback() {
+        const code = this.innerHTML.replace("<!--", "").replace("-->", "").trim()
+        console.log("connectedCallback: Got %s for min-height", this.minHeight);
+        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.passive, this.minHeight).content.cloneNode(true))
+
+        const ideLink = this.shadowRoot!.querySelector("#ide") as HTMLAnchorElement
+        ideLink.onfocus = () => {
+            // Open current contents of editor in IDE
+            const urlParams = new URLSearchParams()
+            urlParams.set("inline", btoa(editor.state.doc.toString()).replace("+", "-").replace("/", "_"))
+            ideLink.href = `https://faustide.grame.fr/?${urlParams.toString()}`
+        }
+
+        const editorEl = this.shadowRoot!.querySelector("#editor") as HTMLDivElement
+        const editor = createEditor(editorEl, code, !this.passive)
+
+        const copyButton = this.shadowRoot!.querySelector("#copy") as HTMLButtonElement
+        
+        copyButton.onclick = () => {
+            if (navigator.clipboard) {
+                navigator.clipboard.writeText(editor.state.doc.toString())
+            } else {
+                console.log("Unable to use clipboard")
+            }
+        }
+        
+        this.editor = editor
+    }
+    
+    attributeChangedCallback(name, oldValue, newValue) {
+      if ((name ==  "passive") && (newValue != null)) {
+          this.passive = true
+      }
+      if ((name ==  "min-height") && (newValue != "")) {
+          this.minHeight = newValue
+          console.log("Got %s for min-height", newValue);
+          
+      }
+    }
+    
+    static get observedAttributes() {
+      return ["passive", "min-height"];
+    }
+
+}

--- a/src/faust-editor-basic.ts
+++ b/src/faust-editor-basic.ts
@@ -3,7 +3,7 @@ import faustCSS from "@shren/faust-ui/dist/esm/index.css?inline"
 import { createEditor, setError, clearError } from "./editor"
 import faustSvg from "./faustText.svg"
 
-function editorTemplate(readonly: boolean = false, minHeight: string = "") {
+function editorTemplate(minHeight: string = "") {
     const editorMinHeight = minHeight != "" ? `min-height: ${minHeight};` : ""
     const template = document.createElement("template")
     template.innerHTML = `
@@ -126,8 +126,7 @@ export default class FaustEditorBasic extends HTMLElement {
 
     connectedCallback() {
         const code = this.innerHTML.replace("<!--", "").replace("-->", "").trim()
-        console.log("connectedCallback: Got %s for min-height", this.minHeight);
-        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.readonly, this.minHeight).content.cloneNode(true))
+        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.minHeight).content.cloneNode(true))
 
         const ideLink = this.shadowRoot!.querySelector("#ide") as HTMLAnchorElement
         ideLink.onfocus = () => {
@@ -154,10 +153,10 @@ export default class FaustEditorBasic extends HTMLElement {
     }
     
     attributeChangedCallback(name, oldValue, newValue) {
-      if ((name ==  "readonly") && (newValue != null)) {
+      if ((name ===  "readonly") && (newValue !== null)) {
           this.readonly = true
       }
-      if ((name ==  "min-height") && (newValue != "")) {
+      if ((name ===  "min-height") && (newValue !== "")) {
           this.minHeight = newValue
       }
     }

--- a/src/faust-editor-basic.ts
+++ b/src/faust-editor-basic.ts
@@ -6,11 +6,16 @@ import faustSvg from "./faustText.svg"
 function editorTemplate(minHeight: string = "") {
     const editorMinHeight = minHeight != "" ? `min-height: ${minHeight};` : ""
     const template = document.createElement("template")
+    let copyButton = `<button title="Copy" class="button" id="copy">${icon({ prefix: "fas", iconName: "copy" }).html[0]}</button>`
+    if (!navigator.clipboard) {
+        console.log("Unable to use clipboard")
+        copyButton = ""
+    }
     template.innerHTML = `
     <div id="root">
         <div id="controls">
             <a title="Open in Faust IDE" id="ide" href="https://faustide.grame.fr/" class="button" target="_blank">${icon({ prefix: "fas", iconName: "up-right-from-square" }).html[0]}</a>
-            <button title="Copy" class="button" id="copy">${icon({ prefix: "fas", iconName: "copy" }).html[0]}</button>
+            ${copyButton}
             <a title="Faust website" id="faust" href="https://faust.grame.fr/" target="_blank"><img src="${faustSvg}" height="15px" /></a>
         </div>
         <div id="content">
@@ -141,11 +146,9 @@ export default class FaustEditorBasic extends HTMLElement {
 
         const copyButton = this.shadowRoot!.querySelector("#copy") as HTMLButtonElement
         
-        copyButton.onclick = () => {
-            if (navigator.clipboard) {
+        if (copyButton !== null) {
+            copyButton.onclick = () => {
                 navigator.clipboard.writeText(editor.state.doc.toString())
-            } else {
-                console.log("Unable to use clipboard")
             }
         }
         

--- a/src/faust-editor-basic.ts
+++ b/src/faust-editor-basic.ts
@@ -3,8 +3,7 @@ import faustCSS from "@shren/faust-ui/dist/esm/index.css?inline"
 import { createEditor, setError, clearError } from "./editor"
 import faustSvg from "./faustText.svg"
 
-function editorTemplate(passive: boolean = false, minHeight: string = "") {
-    const hidden = passive ? "hidden" : ""
+function editorTemplate(readonly: boolean = false, minHeight: string = "") {
     const editorMinHeight = minHeight != "" ? `min-height: ${minHeight};` : ""
     const template = document.createElement("template")
     template.innerHTML = `
@@ -111,7 +110,7 @@ export default class FaustEditorBasic extends HTMLElement {
         super()
     }
     
-    passive = false
+    readonly = false
     minHeight = null
     editor = null
     
@@ -128,7 +127,7 @@ export default class FaustEditorBasic extends HTMLElement {
     connectedCallback() {
         const code = this.innerHTML.replace("<!--", "").replace("-->", "").trim()
         console.log("connectedCallback: Got %s for min-height", this.minHeight);
-        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.passive, this.minHeight).content.cloneNode(true))
+        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.readonly, this.minHeight).content.cloneNode(true))
 
         const ideLink = this.shadowRoot!.querySelector("#ide") as HTMLAnchorElement
         ideLink.onfocus = () => {
@@ -139,7 +138,7 @@ export default class FaustEditorBasic extends HTMLElement {
         }
 
         const editorEl = this.shadowRoot!.querySelector("#editor") as HTMLDivElement
-        const editor = createEditor(editorEl, code, !this.passive)
+        const editor = createEditor(editorEl, code, !this.readonly)
 
         const copyButton = this.shadowRoot!.querySelector("#copy") as HTMLButtonElement
         
@@ -155,18 +154,16 @@ export default class FaustEditorBasic extends HTMLElement {
     }
     
     attributeChangedCallback(name, oldValue, newValue) {
-      if ((name ==  "passive") && (newValue != null)) {
-          this.passive = true
+      if ((name ==  "readonly") && (newValue != null)) {
+          this.readonly = true
       }
       if ((name ==  "min-height") && (newValue != "")) {
           this.minHeight = newValue
-          console.log("Got %s for min-height", newValue);
-          
       }
     }
     
     static get observedAttributes() {
-      return ["passive", "min-height"];
+      return ["readonly", "min-height"];
     }
 
 }

--- a/src/faust-editor-basic.ts
+++ b/src/faust-editor-basic.ts
@@ -142,7 +142,7 @@ export default class FaustEditorBasic extends HTMLElement {
         }
 
         const editorEl = this.shadowRoot!.querySelector("#editor") as HTMLDivElement
-        const editor = createEditor(editorEl, code, !this.readonly)
+        const editor = createEditor(editorEl, code, this.readonly)
 
         const copyButton = this.shadowRoot!.querySelector("#copy") as HTMLButtonElement
         

--- a/src/faust-editor.ts
+++ b/src/faust-editor.ts
@@ -250,7 +250,7 @@ export default class FaustEditor extends HTMLElement {
         }
 
         const editorEl = this.shadowRoot!.querySelector("#editor") as HTMLDivElement
-        const editor = createEditor(editorEl, code, !this.readonly)
+        const editor = createEditor(editorEl, code, this.readonly)
 
         const runButton = this.shadowRoot!.querySelector("#run") as HTMLButtonElement
         const stopButton = this.shadowRoot!.querySelector("#stop") as HTMLButtonElement

--- a/src/faust-editor.ts
+++ b/src/faust-editor.ts
@@ -370,8 +370,12 @@ export default class FaustEditor extends HTMLElement {
             // Create SVG block diagram
             setSVG(svgDiagrams.from("main", code, "")["process.svg"])
 
-            // Set editor size to fit UI size
-            editorEl.style.height = `${Math.max(125, faustUI.minHeight)}px`;
+            // Set editor size to fit UI size or use custom value in attribute
+            if (this.minHeight != null) {
+                editorEl.style.height = this.minHeight;
+            } else {
+                editorEl.style.height = `${Math.max(125, faustUI.minHeight)}px`;
+            }
             faustUIRoot.style.width = faustUI.minWidth * 1.25 + "px"
             faustUIRoot.style.height = faustUI.minHeight * 1.25 + "px"
         }

--- a/src/faust-editor.ts
+++ b/src/faust-editor.ts
@@ -8,18 +8,17 @@ import { createEditor, setError, clearError } from "./editor"
 import { Scope } from "./scope"
 import faustSvg from "./faustText.svg"
 
-function editorTemplate(passive: boolean = false, minHeight: string = "") {
-    const hidden = passive ? "hidden" : ""
+function editorTemplate(readonly: boolean = false, minHeight: string = "") {
     const editorMinHeight = minHeight != "" ? `min-height: ${minHeight};` : ""
     const template = document.createElement("template")
     template.innerHTML = `
     <div id="root">
         <div id="controls">
-            <button title="Run" class="button" id="run" disabled ${hidden}>${icon({ prefix: "fas", iconName: "play" }).html[0]}</button>
-            <button title="Stop" class="button" id="stop" disabled ${hidden}>${icon({ prefix: "fas", iconName: "stop" }).html[0]}</button>
+            <button title="Run" class="button" id="run" disabled>${icon({ prefix: "fas", iconName: "play" }).html[0]}</button>
+            <button title="Stop" class="button" id="stop" disabled>${icon({ prefix: "fas", iconName: "stop" }).html[0]}</button>
             <a title="Open in Faust IDE" id="ide" href="https://faustide.grame.fr/" class="button" target="_blank">${icon({ prefix: "fas", iconName: "up-right-from-square" }).html[0]}</a>
             <button title="Copy" class="button" id="copy">${icon({ prefix: "fas", iconName: "copy" }).html[0]}</button>
-            <select id="audio-input" class="dropdown" disabled ${hidden}>
+            <select id="audio-input" class="dropdown" disabled>
                 <option>Audio input</option>
             </select>
             <!-- TODO: MIDI input
@@ -225,7 +224,7 @@ export default class FaustEditor extends HTMLElement {
         super()
     }
     
-    passive = false
+    readonly = false
     minHeight = null
     editor = null
     
@@ -235,7 +234,7 @@ export default class FaustEditor extends HTMLElement {
 
     connectedCallback() {
         const code = this.innerHTML.replace("<!--", "").replace("-->", "").trim()
-        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.passive, this.minHeight).content.cloneNode(true))
+        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.readonly, this.minHeight).content.cloneNode(true))
 
         const ideLink = this.shadowRoot!.querySelector("#ide") as HTMLAnchorElement
         ideLink.onfocus = () => {
@@ -246,7 +245,7 @@ export default class FaustEditor extends HTMLElement {
         }
 
         const editorEl = this.shadowRoot!.querySelector("#editor") as HTMLDivElement
-        const editor = createEditor(editorEl, code, !this.passive)
+        const editor = createEditor(editorEl, code, !this.readonly)
 
         const runButton = this.shadowRoot!.querySelector("#run") as HTMLButtonElement
         const stopButton = this.shadowRoot!.querySelector("#stop") as HTMLButtonElement
@@ -261,7 +260,7 @@ export default class FaustEditor extends HTMLElement {
         const split = Split([editorEl, sidebar], {
             sizes: [100, 0],
             minSize: [0, 20],
-            gutterSize: this.passive ? 0 : 7,
+            gutterSize: 7,
             snapOffset: 150,
             onDragEnd: () => { scope?.onResize(); spectrum?.onResize() },
         })
@@ -509,16 +508,12 @@ export default class FaustEditor extends HTMLElement {
 
         audioInputSelector.onchange = connectInput
         
-        if (this.passive) {
-            sidebar.remove()
-        }
-        
         this.editor = editor
     }
     
     attributeChangedCallback(name, oldValue, newValue) {
-      if ((name ==  "passive") && (newValue != null)) {
-          this.passive = true
+      if ((name ==  "readonly") && (newValue != null)) {
+          this.readonly = true
       }
       if ((name ==  "min-height") && (newValue != "")) {
           this.minHeight = newValue
@@ -526,7 +521,7 @@ export default class FaustEditor extends HTMLElement {
     }
     
     static get observedAttributes() {
-      return ["passive", "min-height"];
+      return ["readonly", "min-height"];
     }
 
 }

--- a/src/faust-editor.ts
+++ b/src/faust-editor.ts
@@ -8,218 +8,225 @@ import { createEditor, setError, clearError } from "./editor"
 import { Scope } from "./scope"
 import faustSvg from "./faustText.svg"
 
-const template = document.createElement("template")
-template.innerHTML = `
-<div id="root">
-    <div id="controls">
-        <button title="Run" class="button" id="run" disabled>${icon({ prefix: "fas", iconName: "play" }).html[0]}</button>
-        <button title="Stop" class="button" id="stop" disabled>${icon({ prefix: "fas", iconName: "stop" }).html[0]}</button>
-        <a title="Open in Faust IDE" id="ide" href="https://faustide.grame.fr/" class="button" target="_blank">${icon({ prefix: "fas", iconName: "up-right-from-square" }).html[0]}</a>
-        <select id="audio-input" class="dropdown" disabled>
-            <option>Audio input</option>
-        </select>
-        <!-- TODO: MIDI input
-        <select id="midi-input" class="dropdown" disabled>
-            <option>MIDI input</option>
-        </select>
-        -->
-        <!-- TODO: volume control? <input id="volume" type="range" min="0" max="100"> -->
-        <a title="Faust website" id="faust" href="https://faust.grame.fr/" target="_blank"><img src="${faustSvg}" height="15px" /></a>
-    </div>
-    <div id="content">
-        <div id="editor"></div>
-        <div id="sidebar">
-            <div id="sidebar-buttons">
-                <button title="Controls" id="tab-ui" class="button tab" disabled>${icon({ prefix: "fas", iconName: "sliders" }).html[0]}</button>
-                <button title="Block Diagram" id="tab-diagram" class="button tab" disabled>${icon({ prefix: "fas", iconName: "diagram-project" }).html[0]}</button>
-                <button title="Scope" id="tab-scope" class="button tab" disabled>${icon({ prefix: "fas", iconName: "wave-square" }).html[0]}</button>
-                <button title="Spectrum" id="tab-spectrum" class="button tab" disabled>${icon({ prefix: "fas", iconName: "chart-line" }).html[0]}</button>
-            </div>
-            <div id="sidebar-content">
-                <div id="faust-ui"></div>
-                <div id="faust-diagram"></div>
-                <div id="faust-scope"></div>
-                <div id="faust-spectrum"></div>
+function editorTemplate(passive: boolean = false) {
+    const hidden = passive ? "hidden" : ""
+    const template = document.createElement("template")
+    template.innerHTML = `
+    <div id="root">
+        <div id="controls">
+            <button title="Run" class="button" id="run" disabled ${hidden}>${icon({ prefix: "fas", iconName: "play" }).html[0]}</button>
+            <button title="Stop" class="button" id="stop" disabled ${hidden}>${icon({ prefix: "fas", iconName: "stop" }).html[0]}</button>
+            <a title="Open in Faust IDE" id="ide" href="https://faustide.grame.fr/" class="button" target="_blank">${icon({ prefix: "fas", iconName: "up-right-from-square" }).html[0]}</a>
+            <button title="Copy" class="button" id="copy">${icon({ prefix: "fas", iconName: "copy" }).html[0]}</button>
+            <select id="audio-input" class="dropdown" disabled ${hidden}>
+                <option>Audio input</option>
+            </select>
+            <!-- TODO: MIDI input
+            <select id="midi-input" class="dropdown" disabled>
+                <option>MIDI input</option>
+            </select>
+            -->
+            <!-- TODO: volume control? <input id="volume" type="range" min="0" max="100"> -->
+            <a title="Faust website" id="faust" href="https://faust.grame.fr/" target="_blank"><img src="${faustSvg}" height="15px" /></a>
+        </div>
+        <div id="content">
+            <div id="editor"></div>
+            <div id="sidebar">
+                <div id="sidebar-buttons">
+                    <button title="Controls" id="tab-ui" class="button tab" disabled>${icon({ prefix: "fas", iconName: "sliders" }).html[0]}</button>
+                    <button title="Block Diagram" id="tab-diagram" class="button tab" disabled>${icon({ prefix: "fas", iconName: "diagram-project" }).html[0]}</button>
+                    <button title="Scope" id="tab-scope" class="button tab" disabled>${icon({ prefix: "fas", iconName: "wave-square" }).html[0]}</button>
+                    <button title="Spectrum" id="tab-spectrum" class="button tab" disabled>${icon({ prefix: "fas", iconName: "chart-line" }).html[0]}</button>
+                </div>
+                <div id="sidebar-content" >
+                    <div id="faust-ui"></div>
+                    <div id="faust-diagram"></div>
+                    <div id="faust-scope"></div>
+                    <div id="faust-spectrum"></div>
+                </div>
             </div>
         </div>
     </div>
-</div>
-<style>
-    #root {
-        border: 1px solid black;
-        border-radius: 5px;
-        box-sizing: border-box;
-    }
+    <style>
+        #root {
+            border: 1px solid black;
+            border-radius: 5px;
+            box-sizing: border-box;
+        }
 
-    *, *:before, *:after {
-        box-sizing: inherit; 
-    }
+        *, *:before, *:after {
+            box-sizing: inherit; 
+        }
 
-    #controls {
-        background-color: #384d64;
-        border-bottom: 1px solid black;
-        display: flex;
-    }
+        #controls {
+            background-color: #384d64;
+            border-bottom: 1px solid black;
+            display: flex;
+        }
 
-    #faust {
-        margin-left: auto;
-        margin-right: 10px;
-        display: flex;
-        align-items: center;
-    }
+        #faust {
+            margin-left: auto;
+            margin-right: 10px;
+            display: flex;
+            align-items: center;
+        }
 
-    #faust-ui {
-        width: 232px;
-        max-height: 150px;
-    }
+        #faust-ui {
+            width: 232px;
+            max-height: 150px;
+        }
 
-    #faust-scope, #faust-spectrum {
-        min-width: 232px;
-        min-height: 150px;
-    }
+        #faust-scope, #faust-spectrum {
+            min-width: 232px;
+            min-height: 150px;
+        }
 
-    #faust-diagram {
-        max-width: 232px;
-        height: 150px;
-    }
+        #faust-diagram {
+            max-width: 232px;
+            height: 150px;
+        }
 
-    #content {
-        display: flex;
-    }
+        #content {
+            display: flex;
+        }
 
-    #editor {
-        flex-grow: 1;
-        overflow-y: auto;
-    }
+        #editor {
+            flex-grow: 1;
+            overflow-y: auto;
+        }
 
-    #editor .cm-editor {
-        height: 100%;
-    }
+        #editor .cm-editor {
+            height: 100%;
+        }
 
-    .cm-diagnostic {
-        font-family: monospace;
-    }
+        .cm-diagnostic {
+            font-family: monospace;
+        }
 
-    .cm-diagnostic-error {
-        background-color: #fdf2f5 !important;
-        color: #a4000f !important;
-        border-color: #a4000f !important;
-    }
+        .cm-diagnostic-error {
+            background-color: #fdf2f5 !important;
+            color: #a4000f !important;
+            border-color: #a4000f !important;
+        }
 
-    #sidebar {
-        display: flex;
-        max-width: 100%;
-    }
+        #sidebar {
+            display: flex;
+            max-width: 100%;
+        }
 
-    .tab {
-        flex-grow: 1;
-    }
+        .tab {
+            flex-grow: 1;
+        }
 
-    #sidebar-buttons .tab.active {
-        background-color: #bbb;
-    }
+        #sidebar-buttons .tab.active {
+            background-color: #bbb;
+        }
 
-    #sidebar-buttons {
-        background-color: #f5f5f5;
-        display: flex;
-        flex-direction: column;
-    }
+        #sidebar-buttons {
+            background-color: #f5f5f5;
+            display: flex;
+            flex-direction: column;
+        }
 
-    #sidebar-buttons .button {
-        background-color: #f5f5f5;
-        color: #000;
-        width: 20px;
-        height: 20px;
-        padding: 4px;
-    }
+        #sidebar-buttons .button {
+            background-color: #f5f5f5;
+            color: #000;
+            width: 20px;
+            height: 20px;
+            padding: 4px;
+        }
 
-    #sidebar-buttons .button:hover {
-        background-color: #ddd;
-    }
+        #sidebar-buttons .button:hover {
+            background-color: #ddd;
+        }
 
-    #sidebar-buttons .button:active {
-        background-color: #aaa;
-    }
+        #sidebar-buttons .button:active {
+            background-color: #aaa;
+        }
 
-    #sidebar-content {
-        background-color: #fff;
-        border-left: 1px solid #ccc;
-        overflow: auto;
-        flex-grow: 1;
-        max-height: 100%;
-    }
+        #sidebar-content {
+            background-color: #fff;
+            border-left: 1px solid #ccc;
+            overflow: auto;
+            flex-grow: 1;
+            max-height: 100%;
+        }
 
-    #sidebar-content > div {
-        display: none;
-    }
+        #sidebar-content > div {
+            display: none;
+        }
 
-    #sidebar-content > div.active {
-        display: block;
-    }
+        #sidebar-content > div.active {
+            display: block;
+        }
 
-    a.button {
-        appearance: button;
-    }
+        a.button {
+            appearance: button;
+        }
 
-    .button {
-        background-color: #384d64;
-        border: 0;
-        padding: 5px;
-        width: 25px;
-        height: 25px;
-        color: #fff;
-    }
+        .button {
+            background-color: #384d64;
+            border: 0;
+            padding: 5px;
+            width: 25px;
+            height: 25px;
+            color: #fff;
+        }
 
-    .button:hover {
-        background-color: #4b71a1;
-    }
+        .button:hover {
+            background-color: #4b71a1;
+        }
 
-    .button:active {
-        background-color: #373736;
-    }
+        .button:active {
+            background-color: #373736;
+        }
 
-    .button:disabled {
-        opacity: 0.65;
-        cursor: not-allowed;
-        pointer-events: none;
-    }
+        .button:disabled {
+            opacity: 0.65;
+            cursor: not-allowed;
+            pointer-events: none;
+        }
 
-    #controls > .button > svg {
-        width: 15px;
-        height: 15px;
-        vertical-align: top;
-    }
+        #controls > .button > svg {
+            width: 15px;
+            height: 15px;
+            vertical-align: top;
+        }
 
-    .dropdown {
-        height: 19px;
-        margin: 3px 0 3px 10px;
-        border: 0;
-        background: #fff;
-    }
+        .dropdown {
+            height: 19px;
+            margin: 3px 0 3px 10px;
+            border: 0;
+            background: #fff;
+        }
 
-    .gutter {
-        background-color: #f5f5f5;
-        background-repeat: no-repeat;
-        background-position: 50%;
-    }
-    
-    .gutter.gutter-horizontal {
-        background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
-        cursor: col-resize;
-    }
+        .gutter {
+            background-color: #f5f5f5;
+            background-repeat: no-repeat;
+            background-position: 50%;
+        }
+        
+        .gutter.gutter-horizontal {
+            background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
+            cursor: col-resize;
+        }
 
-    ${faustCSS}
-</style>
-`
+        ${faustCSS}
+    </style>
+    `
+    return template
+}
 
 export default class FaustEditor extends HTMLElement {
     constructor() {
         super()
     }
+    
+    passive = false
 
     connectedCallback() {
         const code = this.innerHTML.replace("<!--", "").replace("-->", "").trim()
-        this.attachShadow({ mode: "open" }).appendChild(template.content.cloneNode(true))
+        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.passive).content.cloneNode(true))
 
         const ideLink = this.shadowRoot!.querySelector("#ide") as HTMLAnchorElement
         ideLink.onfocus = () => {
@@ -230,10 +237,11 @@ export default class FaustEditor extends HTMLElement {
         }
 
         const editorEl = this.shadowRoot!.querySelector("#editor") as HTMLDivElement
-        const editor = createEditor(editorEl, code)
+        const editor = createEditor(editorEl, code, !this.passive)
 
         const runButton = this.shadowRoot!.querySelector("#run") as HTMLButtonElement
         const stopButton = this.shadowRoot!.querySelector("#stop") as HTMLButtonElement
+        const copyButton = this.shadowRoot!.querySelector("#copy") as HTMLButtonElement
         const faustUIRoot = this.shadowRoot!.querySelector("#faust-ui") as HTMLDivElement
         const faustDiagram = this.shadowRoot!.querySelector("#faust-diagram") as HTMLDivElement
         const sidebar = this.shadowRoot!.querySelector("#sidebar") as HTMLDivElement
@@ -244,7 +252,7 @@ export default class FaustEditor extends HTMLElement {
         const split = Split([editorEl, sidebar], {
             sizes: [100, 0],
             minSize: [0, 20],
-            gutterSize: 7,
+            gutterSize: this.passive ? 0 : 7,
             snapOffset: 150,
             onDragEnd: () => { scope?.onResize(); spectrum?.onResize() },
         })
@@ -414,7 +422,15 @@ export default class FaustEditor extends HTMLElement {
         for (const [i, tabButton] of tabButtons.entries()) {
             tabButton.onclick = () => openTab(i)
         }
-
+        
+        copyButton.onclick = () => {
+            if (navigator.clipboard) {
+                navigator.clipboard.writeText(editor.state.doc.toString())
+            } else {
+                console.log("Unable to use clipboard")
+            }
+        }
+        
         stopButton.onclick = () => {
             if (node !== undefined) {
                 node.disconnect()
@@ -479,5 +495,20 @@ export default class FaustEditor extends HTMLElement {
         }
 
         audioInputSelector.onchange = connectInput
+        
+        if (this.passive) {
+            sidebar.remove()
+        }
     }
+    
+    attributeChangedCallback(name, oldValue, newValue) {
+      if ((name ==  "passive") && (newValue != null)) {
+          this.passive = true
+      }
+    }
+    
+    static get observedAttributes() {
+      return ["passive"];
+    }
+
 }

--- a/src/faust-editor.ts
+++ b/src/faust-editor.ts
@@ -512,10 +512,10 @@ export default class FaustEditor extends HTMLElement {
     }
     
     attributeChangedCallback(name, oldValue, newValue) {
-      if ((name ==  "readonly") && (newValue != null)) {
+      if ((name ===  "readonly") && (newValue !== null)) {
           this.readonly = true
       }
-      if ((name ==  "min-height") && (newValue != "")) {
+      if ((name ===  "min-height") && (newValue !== "")) {
           this.minHeight = newValue
       }
     }

--- a/src/faust-editor.ts
+++ b/src/faust-editor.ts
@@ -8,8 +8,9 @@ import { createEditor, setError, clearError } from "./editor"
 import { Scope } from "./scope"
 import faustSvg from "./faustText.svg"
 
-function editorTemplate(passive: boolean = false) {
+function editorTemplate(passive: boolean = false, minHeight: string = "") {
     const hidden = passive ? "hidden" : ""
+    const editorMinHeight = minHeight != "" ? `min-height: ${minHeight};` : ""
     const template = document.createElement("template")
     template.innerHTML = `
     <div id="root">
@@ -49,6 +50,7 @@ function editorTemplate(passive: boolean = false) {
     </div>
     <style>
         #root {
+            overflow:hidden
             border: 1px solid black;
             border-radius: 5px;
             box-sizing: border-box;
@@ -97,6 +99,7 @@ function editorTemplate(passive: boolean = false) {
 
         #editor .cm-editor {
             height: 100%;
+            ${minHeight != "" ? `min-height: ${minHeight};` : ""}
         }
 
         .cm-diagnostic {
@@ -223,10 +226,16 @@ export default class FaustEditor extends HTMLElement {
     }
     
     passive = false
+    minHeight = null
+    editor = null
+    
+    getCodeString() {
+        return this.editor.state.doc.toString()
+    }
 
     connectedCallback() {
         const code = this.innerHTML.replace("<!--", "").replace("-->", "").trim()
-        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.passive).content.cloneNode(true))
+        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.passive, this.minHeight).content.cloneNode(true))
 
         const ideLink = this.shadowRoot!.querySelector("#ide") as HTMLAnchorElement
         ideLink.onfocus = () => {
@@ -499,16 +508,21 @@ export default class FaustEditor extends HTMLElement {
         if (this.passive) {
             sidebar.remove()
         }
+        
+        this.editor = editor
     }
     
     attributeChangedCallback(name, oldValue, newValue) {
       if ((name ==  "passive") && (newValue != null)) {
           this.passive = true
       }
+      if ((name ==  "min-height") && (newValue != "")) {
+          this.minHeight = newValue
+      }
     }
     
     static get observedAttributes() {
-      return ["passive"];
+      return ["passive", "min-height"];
     }
 
 }

--- a/src/faust-editor.ts
+++ b/src/faust-editor.ts
@@ -8,16 +8,21 @@ import { createEditor, setError, clearError } from "./editor"
 import { Scope } from "./scope"
 import faustSvg from "./faustText.svg"
 
-function editorTemplate(readonly: boolean = false, minHeight: string = "") {
+function editorTemplate(minHeight: string = "") {
     const editorMinHeight = minHeight != "" ? `min-height: ${minHeight};` : ""
     const template = document.createElement("template")
+    let copyButton = `<button title="Copy" class="button" id="copy">${icon({ prefix: "fas", iconName: "copy" }).html[0]}</button>`
+    if (!navigator.clipboard) {
+        console.log("Unable to use clipboard")
+        copyButton = ""
+    }
     template.innerHTML = `
     <div id="root">
         <div id="controls">
             <button title="Run" class="button" id="run" disabled>${icon({ prefix: "fas", iconName: "play" }).html[0]}</button>
             <button title="Stop" class="button" id="stop" disabled>${icon({ prefix: "fas", iconName: "stop" }).html[0]}</button>
             <a title="Open in Faust IDE" id="ide" href="https://faustide.grame.fr/" class="button" target="_blank">${icon({ prefix: "fas", iconName: "up-right-from-square" }).html[0]}</a>
-            <button title="Copy" class="button" id="copy">${icon({ prefix: "fas", iconName: "copy" }).html[0]}</button>
+            ${copyButton}
             <select id="audio-input" class="dropdown" disabled>
                 <option>Audio input</option>
             </select>
@@ -234,7 +239,7 @@ export default class FaustEditor extends HTMLElement {
 
     connectedCallback() {
         const code = this.innerHTML.replace("<!--", "").replace("-->", "").trim()
-        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.readonly, this.minHeight).content.cloneNode(true))
+        this.attachShadow({ mode: "open" }).appendChild(editorTemplate(this.minHeight).content.cloneNode(true))
 
         const ideLink = this.shadowRoot!.querySelector("#ide") as HTMLAnchorElement
         ideLink.onfocus = () => {
@@ -435,11 +440,9 @@ export default class FaustEditor extends HTMLElement {
             tabButton.onclick = () => openTab(i)
         }
         
-        copyButton.onclick = () => {
-            if (navigator.clipboard) {
+        if (copyButton !== null) {
+            copyButton.onclick = () => {
                 navigator.clipboard.writeText(editor.state.doc.toString())
-            } else {
-                console.log("Unable to use clipboard")
             }
         }
         

--- a/src/faust-editor.ts
+++ b/src/faust-editor.ts
@@ -50,7 +50,7 @@ function editorTemplate(passive: boolean = false, minHeight: string = "") {
     </div>
     <style>
         #root {
-            overflow:hidden
+            overflow:hidden;
             border: 1px solid black;
             border-radius: 5px;
             box-sizing: border-box;

--- a/src/main-basic.ts
+++ b/src/main-basic.ts
@@ -1,0 +1,11 @@
+import { library } from "@fortawesome/fontawesome-svg-core"
+import { faPlay, faStop, faUpRightFromSquare, faSquareCaretLeft, faAnglesLeft, faAnglesRight, faSliders, faDiagramProject, faWaveSquare, faChartLine, faPowerOff, faCopy } from "@fortawesome/free-solid-svg-icons"
+
+for (const icon of [faPlay, faStop, faUpRightFromSquare, faSquareCaretLeft, faAnglesLeft, faAnglesRight, faSliders, faDiagramProject, faWaveSquare, faChartLine, faPowerOff, faCopy]) {
+    library.add(icon)
+}
+
+import FaustEditorBasic from "./faust-editor-basic"
+
+customElements.define("faust-editor-basic", FaustEditorBasic)
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,7 @@
 import FaustEditor from "./faust-editor"
+import FaustEditorBasic from "./faust-editor-basic"
 import FaustWidget from "./faust-widget"
 
 customElements.define("faust-editor", FaustEditor)
+customElements.define("faust-editor-basic", FaustEditorBasic)
 customElements.define("faust-widget", FaustWidget)

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,17 +1,20 @@
 import { resolve } from 'path'
 import { defineConfig } from 'vite'
 
-export default defineConfig({
-    build: {
-        lib: {
-            entry: resolve(__dirname, process.env.FAUST_WEB_BASIC ? "src/main-basic.ts" : "src/main.ts"),
-            name: "faust_web_component",
-            formats: ["iife"],
-            fileName: () => {
-                if (process.env.FAUST_WEB_BASIC) { return "faust-web-component-basic.js" }
-                else { return "faust-web-component.js" }
+export default defineConfig(({ mode }) => {
+    return {
+        build: {
+            lib: {
+                entry: resolve(__dirname, mode == "basic" ? "src/main-basic.ts" : "src/main.ts"),
+                name: "faust_web_component",
+                formats: ["iife"],
+                fileName: () => {
+                    if (mode == "basic") { return "faust-web-component-basic.js" }
+                    else { return "faust-web-component.js" }
+                },
             },
-        },
-        sourcemap: true,
-    },
+            sourcemap: true,
+            emptyOutDir: false,
+        }
+    }
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,10 +4,13 @@ import { defineConfig } from 'vite'
 export default defineConfig({
     build: {
         lib: {
-            entry: resolve(__dirname, "src/main.ts"),
+            entry: resolve(__dirname, process.env.FAUST_WEB_BASIC ? "src/main-basic.ts" : "src/main.ts"),
             name: "faust_web_component",
             formats: ["iife"],
-            fileName: () => "faust-web-component.js",
+            fileName: () => {
+                if (process.env.FAUST_WEB_BASIC) { return "faust-web-component-basic.js" }
+                else { return "faust-web-component.js" }
+            },
         },
         sourcemap: true,
     },


### PR DESCRIPTION
See the readme and the [demo page](https://synthe.tiseur.fr/faust-web-component/#readonlyandbasic) for an example of what it looks like!  
I've made this mostly for [a Faust paste web service I'm building](https://pasfa.synthe.tiseur.fr).

This PR could use some polishing but the claimed features are available and working.

Please do not merge until I've ironed out some details and removed the fork notice in readme.

As for the hack in 0f4b74f58c2135f16552aeb841b37aff8784fae4 to force building 2 variants, ViteJS/Rollup currently don't make this possible and do not seem to plan to support it any time soon ... *sigh* ... This has been a hugely frustrating waste of time and energy to end up with a stupid workaround, I won't spend more time on this though I'll gladly welcome contributions.